### PR TITLE
changed project generation

### DIFF
--- a/vscode.lua
+++ b/vscode.lua
@@ -32,9 +32,9 @@ function vscode.generateProject(prj)
     p.indent("  ")
 
     if project.isc(prj) or project.iscpp(prj) then
-        p.generate(prj, prj.location .. '/' .. prj.name .. "/.vscode/tasks.json", vscode.project.vscode_tasks)
-        p.generate(prj, prj.location .. '/' .. prj.name .. "/.vscode/launch.json", vscode.project.vscode_launch)
-        p.generate(prj, prj.location .. '/' .. prj.name .. "/.vscode/c_cpp_properties.json", vscode.project.vscode_c_cpp_properties)
+        p.generate(prj, prj.location .. "/.vscode/launch.json", vscode.project.vscode_launch)
+        p.generate(prj, prj.location .. "/.vscode/tasks.json", vscode.project.vscode_tasks)
+        p.generate(prj, prj.location .. "/.vscode/c_cpp_properties.json", vscode.project.vscode_c_cpp_properties)
     end
 end
 

--- a/vscode_project.lua
+++ b/vscode_project.lua
@@ -50,34 +50,10 @@ function symlink(target, link)
 	end
 end
 
--- VS Code only scans for project files inside the project's directory, so symlink them into
--- the project's directory.
-function m.files(prj)
-	local node_path = ''
-	local tr = project.getsourcetree(prj)
-	tree.traverse(tr, {
-		onbranchenter = function(node, depth)
-			node_path = node_path .. '/' .. node.name
-		end,
-		onbranchexit = function(node, depth)
-			node_path = node_path:sub(1, node_path:len()-(node.name:len()+1))
-		end,
-		onleaf = function(node, depth)
-			local full_path = prj.location .. node_path
-			os.mkdir(full_path)
-			symlink(node.abspath, full_path)
-		end
-	}, true)
-end
-
-
 --
 -- Project: Generate vscode tasks.json.
 --
 function m.vscode_tasks(prj)
-
-	m.files(prj)
-
 	p.utf8()
 	--TODO task per project
 	_p('{')
@@ -88,7 +64,7 @@ function m.vscode_tasks(prj)
 			_p(2, '"command": "clear && time make -r -j`nproc`",')
 			_p(2, '"args": [],')
 			_p(2, '"options": {')
-				_p(3, '"cwd": "${workspaceFolder}/../"')
+				_p(3, '"cwd": "${workspaceFolder}/"')
 			_p(2, '},')
 			_p(2, '"problemMatcher": [')
 				_p(3, '"$gcc"')

--- a/vscode_workspace.lua
+++ b/vscode_workspace.lua
@@ -34,7 +34,7 @@ function m.generate(wks)
 			local prj = n.project
 
 			-- Build a relative path from the workspace file to the project file
-			local prjpath = path.getrelative(prj.workspace.location, prj.location .. '/' .. prj.name)
+			local prjpath = path.getrelative(prj.workspace.location, prj.location)
 			p.w('{')
 			p.w('"path": "%s"', prjpath)
 			p.w('},')


### PR DESCRIPTION
I found this fork that changes the generated project that the .vscode folder is at the workspace root and the vscode-workspace file actually contains the project files

(I don't know why but the original didn't work at all for me. None of my files was included, and this fork solved my problem)