### PR TITLE
removed symbolic links and added cfg.platform to Build and debug

### DIFF
--- a/vscode.lua
+++ b/vscode.lua
@@ -32,9 +32,9 @@ function vscode.generateProject(prj)
     p.indent("  ")
 
     if project.isc(prj) or project.iscpp(prj) then
-        p.generate(prj, prj.location .. '/' .. prj.name .. "/.vscode/tasks.json", vscode.project.vscode_tasks)
-        p.generate(prj, prj.location .. '/' .. prj.name .. "/.vscode/launch.json", vscode.project.vscode_launch)
-        p.generate(prj, prj.location .. '/' .. prj.name .. "/.vscode/c_cpp_properties.json", vscode.project.vscode_c_cpp_properties)
+        p.generate(prj, prj.location .. "/.vscode/tasks.json", vscode.project.vscode_tasks)
+        p.generate(prj, prj.location .. "/.vscode/launch.json", vscode.project.vscode_launch)
+        p.generate(prj, prj.location .. "/.vscode/c_cpp_properties.json", vscode.project.vscode_c_cpp_properties)
     end
 end
 

--- a/vscode_project.lua
+++ b/vscode_project.lua
@@ -53,21 +53,7 @@ end
 -- VS Code only scans for project files inside the project's directory, so symlink them into
 -- the project's directory.
 function m.files(prj)
-	local node_path = ''
-	local tr = project.getsourcetree(prj)
-	tree.traverse(tr, {
-		onbranchenter = function(node, depth)
-			node_path = node_path .. '/' .. node.name
-		end,
-		onbranchexit = function(node, depth)
-			node_path = node_path:sub(1, node_path:len()-(node.name:len()+1))
-		end,
-		onleaf = function(node, depth)
-			local full_path = prj.location .. node_path
-			os.mkdir(full_path)
-			symlink(node.abspath, full_path)
-		end
-	}, true)
+	
 end
 
 
@@ -123,7 +109,7 @@ function m.vscode_launch(prj)
 		else
 			_p(1, ',{')
 		end
-			_p(2, '"name": "%s: Build and debug",', prj.name)
+			_p(2, '"name": "%s (%s): Build and debug",', prj.name,cfg.platform)
 			_p(2, '"type": "cppdbg",')
 			_p(2, '"request": "launch",')
 			_p(2, '"program": "%s/%s",', cfg.buildtarget.directory, prj.name)

--- a/vscode_workspace.lua
+++ b/vscode_workspace.lua
@@ -34,7 +34,7 @@ function m.generate(wks)
 			local prj = n.project
 
 			-- Build a relative path from the workspace file to the project file
-			local prjpath = path.getrelative(prj.workspace.location, prj.location .. '/' .. prj.name)
+			local prjpath = path.getrelative(prj.workspace.location, prj.location)
 			p.w('{')
 			p.w('"path": "%s"', prjpath)
 			p.w('},')


### PR DESCRIPTION
-Removed symbolic links and just used symbolic links direct references because it may mess up a project git history as it cant be easily added to to .gitnore.

-Also added cfg.platform to Build and debug label. It helps people that have a lot of planforms